### PR TITLE
Move from dev-dependencies to dependencies for keycloak-js

### DIFF
--- a/maltd-frontend/package.json
+++ b/maltd-frontend/package.json
@@ -18,7 +18,8 @@
     "react-icons": "^3.9.0",
     "react-scripts": "3.4.0",
     "react-test-renderer": "^16.12.0",
-    "reactstrap": "^8.4.1"
+    "reactstrap": "^8.4.1",
+    "keycloak-js": "^9.0.0"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -99,7 +100,6 @@
     "eslint-plugin-react-hooks": "^1.7.0",
     "husky": "^4.2.0",
     "jest-sonar-reporter": "^2.0.0",
-    "keycloak-js": "^9.0.0",
     "prettier": "1.19.1",
     "pretty-quick": "^2.0.1",
     "regenerator-runtime": "^0.13.3"


### PR DESCRIPTION
## Overview

The `keycloak-js` lib needs to be a dependency and not a dev-dependency because it is needed outside of dev environment (openshift)