### PR TITLE
Pb logging from config config validation

### DIFF
--- a/api/src/BcGov.Malt.Web/Models/Configuration/ProjectConfigurationExtensions.cs
+++ b/api/src/BcGov.Malt.Web/Models/Configuration/ProjectConfigurationExtensions.cs
@@ -71,14 +71,19 @@ namespace BcGov.Malt.Web.Models.Configuration
                         errors.Add($"Project resource type is invalid at index {i}");
                     }
 
-                    if (string.IsNullOrEmpty(projectResource.ClientId))
+                    if (projectResource.Type == ProjectType.Dynamics && string.IsNullOrEmpty(projectResource.ClientId))
                     {
-                        errors.Add($"Project resource ClientId is missing at index {i}");
+                        errors.Add($"Dynamics Project resource ClientId is missing at index {i}");
                     }
 
-                    if (string.IsNullOrEmpty(projectResource.ClientSecret))
+                    if (projectResource.Type == ProjectType.Dynamics && string.IsNullOrEmpty(projectResource.ClientSecret))
                     {
-                        errors.Add($"Project resource ClientSecret is missing at index {i}");
+                        errors.Add($"Dynamics Project resource ClientSecret is missing at index {i}");
+                    }
+
+                    if (projectResource.Type == ProjectType.SharePoint && string.IsNullOrEmpty(projectResource.RelyingPartyIdentifier))
+                    {
+                        errors.Add($"SharePoint Project resource RelyingPartyIdentifier is missing at index {i}");
                     }
 
                     if (string.IsNullOrEmpty(projectResource.Username))

--- a/api/src/BcGov.Malt.Web/Program.cs
+++ b/api/src/BcGov.Malt.Web/Program.cs
@@ -66,13 +66,15 @@ namespace BcGov.Malt.Web
 
         private static void ConfigureLogging()
         {
-            var configuration = new LoggerConfiguration()
-                .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
-                .Enrich.FromLogContext();
+            var configuration = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json")
+                .Build();
 
-            configuration.WriteTo.Console();
+            var logger = new LoggerConfiguration()
+                .ReadFrom.Configuration(configuration)
+                .CreateLogger();
 
-            Log.Logger = configuration.CreateLogger();
+            Log.Logger = logger;
         }
     }
 }

--- a/api/src/BcGov.Malt.Web/appsettings.json
+++ b/api/src/BcGov.Malt.Web/appsettings.json
@@ -1,3 +1,21 @@
 {
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+
+  "Serilog": {
+    "Using": [ "Serilog.Sinks.Console" ],
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}{NewLine}{Properties:j}"
+      }
+    ],
+    "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId" ]
+  }
 }

--- a/api/src/BcGov.Malt.Web/appsettings.json
+++ b/api/src/BcGov.Malt.Web/appsettings.json
@@ -13,7 +13,9 @@
     "WriteTo": [
       {
         "Name": "Console",
-        "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}{NewLine}{Properties:j}"
+        "Args": {
+          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Properties:j}{NewLine}{Exception}"
+        }
       }
     ],
     "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId" ]


### PR DESCRIPTION
# Description

This change contains the following changes:

1. Changes to the logging configuration to read from appsettings.json. Other configuration can still come from env vars or user settings (Development).
2. Configuration settings for ClientId and ClientSecret are only required for Dynamics, not Sharepoint.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Check the logging output by running the API.

