### PR TITLE
Switch to cross platform LDAP search library

### DIFF
--- a/api/src/BcGov.Malt.Web/BcGov.Malt.Web.csproj
+++ b/api/src/BcGov.Malt.Web/BcGov.Malt.Web.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.1" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="3.1.0" />
+    <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="3.0.2" />
     <PackageReference Include="Polly" Version="7.2.0" />
     <PackageReference Include="Polly.Contrib.Simmy" Version="0.3.0" />
     <PackageReference Include="Serilog" Version="2.9.0" />


### PR DESCRIPTION
# Description

Changes LDAP search to use Novell.Directory.Ldap.NETStandard instead of System.DirectoryServices.Protocols since the latter does not work on OpenShift (Linux/Mac)

For this change, you will need to update your configuration setting for LDAP Username to contained the distinguished name format.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

