### PR TITLE
Fix start in case HttpClient is not registered

### DIFF
--- a/api/src/BcGov.Malt.Web/Services/ProjectExtensions.cs
+++ b/api/src/BcGov.Malt.Web/Services/ProjectExtensions.cs
@@ -16,7 +16,7 @@ namespace BcGov.Malt.Web.Services
         /// </summary>
         /// <param name="services">The services.</param>
         /// <param name="configuration">The configuration.</param>
-        public static void AddProjectAccess(this IServiceCollection services, IConfiguration configuration)
+        public static void ConfigureProjectResources(this IServiceCollection services, IConfiguration configuration)
         {
             // read the configuration and register the types for each 
             List<ProjectConfiguration> projects = configuration.GetProjectConfigurations()

--- a/api/src/BcGov.Malt.Web/Startup.cs
+++ b/api/src/BcGov.Malt.Web/Startup.cs
@@ -93,7 +93,7 @@ namespace BcGov.Malt.Web
                 };
             });
 
-            // add all the handlers in this project
+            // add all the handlers in this assembly
             services.AddMediatR(GetType().Assembly);
 
             AddSwaggerGen(services);
@@ -102,17 +102,16 @@ namespace BcGov.Malt.Web
 
             // this will configure the service correctly, comment out for now until
             // the services are working
-            services.AddProjectAccess(Configuration);
+            services.ConfigureProjectResources(Configuration);
 
             services.AddTransient<IProjectService, ProjectService>();
             services.AddTransient<IUserSearchService, LdapUserSearchService>();
-
-            // singleton for now since these are in memory (testing) implementations
-            //services.AddSingleton<IUserSearchService, InMemoryUserSearchService>();
-            //services.AddTransient<IUserManagementService, InMemoryUserManagementService>();
-
             services.AddTransient<IUserManagementService, UserManagementService>();
             services.AddTransient<IODataClientFactory, DefaultODataClientFactory>();
+
+            // Add HttpClient and IHttpClientFactory in case the project resources do not register it
+            // The DefaultODataClientFactory has dependency on IHttpClientFactory.
+            services.AddHttpClient();
 
             services.AddTransient<ITokenCache, TokenCache>();
         }


### PR DESCRIPTION
# Description

This change fixes a startup crash if a valid dynamics project is not added. One service requires IHttpClientFactory and if AddHttpClient() is not called, IHttpClientFactory will have not been added to the services collection

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Built and run locally.

