### PR TITLE
fix default logging level, add support for configure logging using en…

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -20,21 +20,21 @@ In dotnet, there are multiple options for configuring applications. For non-Visu
 
 Below, _n_ and _m_ are place holders for array indexes, 0, 1, 2, etc
 
-| Variable Name | Description |
-| -- | -- |
-| PROJECTS\_\__n_\_\_NAME | The unique name of the project. This will be displayed to the users. |
-| PROJECTS\_\__n_\_\_RESOURCES\_\__m_\_\_RESOURCE | The URL of the resource. Dynamics or Sharepoint site urls |
-| PROJECTS\_\__n_\_\_RESOURCES\_\__m_\_\_TYPE | The type of the resource, Dynamics or Sharepoint  |
-| PROJECTS\_\__n_\_\_RESOURCES\_\__m_\_\_AUTHORIZATIONURI | The URL where authenication occurs, STS/SAML or OAuth endpoints |
-| PROJECTS\_\__n_\_\_RESOURCES\_\__m_\_\_USERNAME | The authentication username |
-| PROJECTS\_\__n_\_\_RESOURCES\_\__m_\_\_PASSWORD | The authentication password |
-| PROJECTS\_\__n_\_\_RESOURCES\_\__m_\_\_CLIENTID | Dynamics only. The client id for OAuth |
-| PROJECTS\_\__n_\_\_RESOURCES\_\__m_\_\_CLIENTSECRET | Dynamics only. The  client secret for OAuth |
-| PROJECTS\_\__n_\_\_RESOURCES\_\__m_\_\_RELYINGPARTYIDENTIFIER | Sharepoint only. The relying party identifier for SAML auth |
-| LDAP\_\_SERVER | The host name of the Active Directory server |
-| LDAP\_\_DISTINGUISHEDNAME | The distinguished name of the directory to search |
-| LDAP\_\_USERNAME | The username of the user to authenicate to Active Directory with |
-| LDAP\_\_PASSWORD | The password of the user to authenicate to Active Directory with |
+| Variable Name                                                 | Description                                                          |
+| ------------------------------------------------------------- | -------------------------------------------------------------------- |
+| PROJECTS\_\__n_\_\_NAME                                       | The unique name of the project. This will be displayed to the users. |
+| PROJECTS\_\__n_\_\_RESOURCES\_\__m_\_\_RESOURCE               | The URL of the resource. Dynamics or Sharepoint site urls            |
+| PROJECTS\_\__n_\_\_RESOURCES\_\__m_\_\_TYPE                   | The type of the resource, Dynamics or Sharepoint                     |
+| PROJECTS\_\__n_\_\_RESOURCES\_\__m_\_\_AUTHORIZATIONURI       | The URL where authenication occurs, STS/SAML or OAuth endpoints      |
+| PROJECTS\_\__n_\_\_RESOURCES\_\__m_\_\_USERNAME               | The authentication username                                          |
+| PROJECTS\_\__n_\_\_RESOURCES\_\__m_\_\_PASSWORD               | The authentication password                                          |
+| PROJECTS\_\__n_\_\_RESOURCES\_\__m_\_\_CLIENTID               | Dynamics only. The client id for OAuth                               |
+| PROJECTS\_\__n_\_\_RESOURCES\_\__m_\_\_CLIENTSECRET           | Dynamics only. The client secret for OAuth                           |
+| PROJECTS\_\__n_\_\_RESOURCES\_\__m_\_\_RELYINGPARTYIDENTIFIER | Sharepoint only. The relying party identifier for SAML auth          |
+| LDAP\_\_SERVER                                                | The host name of the Active Directory server                         |
+| LDAP\_\_DISTINGUISHEDNAME                                     | The distinguished name of the directory to search                    |
+| LDAP\_\_USERNAME                                              | The username of the user to authenicate to Active Directory with     |
+| LDAP\_\_PASSWORD                                              | The password of the user to authenicate to Active Directory with     |
 
 All values are required except for these cases,
 
@@ -70,4 +70,30 @@ dotnet user-secrets set LDAP:Server ""
 dotnet user-secrets set LDAP:DistinguishedName ""
 dotnet user-secrets set LDAP:Username ""
 dotnet user-secrets set LDAP:Password ""
+```
+
+## Logging
+
+In development, using Seq can be useful for viewing / searching logs. This section describes how to configure your enviroment to
+send logs to [Seq](https://datalust.co/seq). This solution uses the [Serilog Seq Sink](https://github.com/serilog/serilog-sinks-seq).
+HEre are example using user secrets.
+
+**Note**: currently to configure logging using either the `appsettings.Development.json` file or `user secrets`,
+the solution needs to be DEBUG build.
+
+```
+dotnet user-secrets set Serilog:Using:0                                 "Serilog.Sinks.Seq"
+dotnet user-secrets set Serilog:MinimumLevel:Default                    "Verbose"
+
+dotnet user-secrets set Serilog:MinimumLevel:Override:Microsoft         "Warning"
+dotnet user-secrets set Serilog:MinimumLevel:Override:System            "Warning"
+
+dotnet user-secrets set Serilog:WriteTo:0:Name                          "Seq"
+dotnet user-secrets set Serilog:WriteTo:0:Args:serverUrl                "http://localhost:5341"
+dotnet user-secrets set Serilog:WriteTo:0:Args:apiKey                   "none"
+dotnet user-secrets set Serilog:WriteTo:0:Args:restrictedToMinimumLevel "Verbose"
+
+dotnet user-secrets set Serilog:Enrich:0                                "FromLogContext"
+dotnet user-secrets set Serilog:Enrich:1                                "WithMachineName"
+dotnet user-secrets set Serilog:Enrich:2                                "WithThreadId"
 ```

--- a/api/src/BcGov.Malt.Web/BcGov.Malt.Web.csproj
+++ b/api/src/BcGov.Malt.Web/BcGov.Malt.Web.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="refit" Version="5.0.23" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
     <PackageReference Include="Simple.OData.V4.Client" Version="5.11.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0" />

--- a/api/src/BcGov.Malt.Web/Program.cs
+++ b/api/src/BcGov.Malt.Web/Program.cs
@@ -66,9 +66,19 @@ namespace BcGov.Malt.Web
 
         private static void ConfigureLogging()
         {
-            var configuration = new ConfigurationBuilder()
-                .AddJsonFile("appsettings.json")
-                .Build();
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddJsonFile("appsettings.json");
+
+            // Added before AddUserSecrets to let user secrets override environment variables.
+            configurationBuilder.AddEnvironmentVariables();
+
+#if DEBUG
+            // use appsettings.Development.json and user secrets on debug builds
+            configurationBuilder.AddJsonFile("appsettings.Development.json", optional: true);
+            configurationBuilder.AddUserSecrets(typeof(Program).Assembly, optional: true);
+#endif
+
+            var configuration = configurationBuilder.Build();
 
             var logger = new LoggerConfiguration()
                 .ReadFrom.Configuration(configuration)

--- a/api/src/BcGov.Malt.Web/appsettings.json
+++ b/api/src/BcGov.Malt.Web/appsettings.json
@@ -7,10 +7,10 @@
   "Serilog": {
     "Using": ["Serilog.Sinks.Console"],
     "MinimumLevel": {
-      "Default": "Debug",
+      "Default": "Information",
       "Override": {
-        "Microsoft": "Verbose",
-        "System": "Verbose"
+        "Microsoft": "Warning",
+        "System": "Warning"
       }
     },
     "WriteTo": [


### PR DESCRIPTION
# Description

This change fixes a previous logging configuration change back to Information default level. It also adds support for developers to use Seq via configuration.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested locally using Seq

