### PR TITLE
Adding Authorization Flow

### DIFF
--- a/maltd-frontend/.env.example
+++ b/maltd-frontend/.env.example
@@ -3,3 +3,4 @@ REACT_APP_KEYCLOAK_REDIRECT_URI=<redirect_url>
 REACT_APP_KEYCLOAK_URL=<keycloak_url>
 REACT_APP_KEYCLOAK_REALM=<keycloak_realm>
 REACT_APP_KEYCLOAK_CLIENT_ID=<keycloak_client_id>
+REACT_APP_KEYCLOAK_ACCESS_ROLE=<keycloak_access_role>

--- a/maltd-frontend/src/components/hoc/AuthenticationGuard.js
+++ b/maltd-frontend/src/components/hoc/AuthenticationGuard.js
@@ -50,7 +50,7 @@ export default function AuthenticationGuard() {
       })
       .success(() => {
         keycloak.loadUserInfo().success();
-        if(accessRole != null && accessRole != "" && keycloak.tokenParsed.realm_access.roles.indexOf(accessRole) != -1){
+        if (accessRole && keycloak.tokenParsed.realm_access.roles.indexOf(accessRole) !== -1){
             localStorage.setItem("jwt", keycloak.token);
             setAuthedKeycloak(keycloak);
         }else{

--- a/maltd-frontend/src/components/hoc/AuthenticationGuard.js
+++ b/maltd-frontend/src/components/hoc/AuthenticationGuard.js
@@ -5,6 +5,7 @@ import MainPage from "../page/MainPage/MainPage";
 let url;
 let realm;
 let clientId;
+let accessRole;
 
 if (process.env.REACT_APP_KEYCLOAK_URL)
   url = process.env.REACT_APP_KEYCLOAK_URL;
@@ -14,6 +15,9 @@ if (process.env.REACT_APP_KEYCLOAK_REALM)
 
 if (process.env.REACT_APP_KEYCLOAK_CLIENT_ID)
   clientId = process.env.REACT_APP_KEYCLOAK_CLIENT_ID;
+
+if (process.env.REACT_APP_KEYCLOAK_ACCESS_ROLE)
+  accessRole = process.env.REACT_APP_KEYCLOAK_ACCESS_ROLE;
 
 const KEYCLOAK = {
   url,
@@ -46,8 +50,15 @@ export default function AuthenticationGuard() {
       })
       .success(() => {
         keycloak.loadUserInfo().success();
-        localStorage.setItem("jwt", keycloak.token);
-        setAuthedKeycloak(keycloak);
+        if(accessRole != null && accessRole != "" && keycloak.tokenParsed.realm_access.roles.indexOf(accessRole) != -1){
+            localStorage.setItem("jwt", keycloak.token);
+            setAuthedKeycloak(keycloak);
+        }else{
+             keycloak.clearToken();
+             localStorage.clear();
+             alert('Authenticated but not Authorized, request access from your portal administrator');                 
+             window.location.assign(keycloak.createLogoutUrl());
+        }        
       });
   }
 


### PR DESCRIPTION
Portal will only allow users who Authenticate as well as Authorize as users of the portal, as set by specific access role from environment

# Description

* Authorization role is set by name in the environment
* After Authentication, keycloak access roles are checked for Authorization role
* If role is present, Portal access is granted
* If role is not present, user is informed they have not authorized and to contact admin for access, and return to IDIR login page

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I have built and deployed these changes

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## For bcgov contributors:

this PR fixes jira ticket: **put the jira ticket # here**
