### PR TITLE
Adjust the sdk version so we can build on OpenShift

### DIFF
--- a/api/src/global.json
+++ b/api/src/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.302",
+    "version": "3.1.106",
     "rollForward": "minor"
   }
 }


### PR DESCRIPTION
# Description

Change SDK version to SDK 3.1.106 to allow building on openshift