### PR TITLE
Do not log error when response comes back 302 Found

### DIFF
--- a/api/src/BcGov.Malt.Web/Services/Sharepoint/SamlAuthenticator.cs
+++ b/api/src/BcGov.Malt.Web/Services/Sharepoint/SamlAuthenticator.cs
@@ -175,7 +175,8 @@ namespace BcGov.Malt.Web.Services.Sharepoint
 
             var httpPostResponse = await client.PostAsync(trustUri, content);
 
-            if (!httpPostResponse.IsSuccessStatusCode)
+            // the response could be 302 as well
+            if (!httpPostResponse.IsSuccessStatusCode && httpPostResponse.StatusCode != HttpStatusCode.Found)
             {
                 _logger.LogError("POST request to {TrustUri} was not successful, HttpStatusCode={HttpStatusCode}",
                     trustUri,


### PR DESCRIPTION
# Description

Requests to trust endpoints can return 302 Found which should not be logged as an error. The response still has FedAuth cookie that can be used.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
