### PR TITLE
set default connection limit 

### DIFF
--- a/api/src/BcGov.Malt.Web/Program.cs
+++ b/api/src/BcGov.Malt.Web/Program.cs
@@ -242,18 +242,34 @@ namespace BcGov.Malt.Web
 
         private static void ConfigureServicePointManager(ILogger logger)
         {
+            // DefaultConnectionLimit : The maximum number of concurrent connections allowed to a single host (ServicePoint)
+            int defaultConnectionLimit;
+            
+            var value = Environment.GetEnvironmentVariable("DEFAULTCONNECTIONLIMIT");
+            if (!string.IsNullOrEmpty(value) && int.TryParse(value, out defaultConnectionLimit))
+            {
+                logger.Information("Environment variable DEFAULTCONNECTIONLIMIT is set to {DefaultConnectionLimit}", defaultConnectionLimit);
+            }
+            else
+            {
+                logger.Information("Environment variable DEFAULTCONNECTIONLIMIT is not set or is not an integer, defaulting DefaultConnectionLimit to 50");
+                defaultConnectionLimit = 50;
+            }
+
+            ServicePointManager.DefaultConnectionLimit = defaultConnectionLimit;
+
             logger.Information("ServicePointManager settings = {@ServicePointManager}",
-                new
-                {
-                    ServicePointManager.UseNagleAlgorithm,
-                    ServicePointManager.DnsRefreshTimeout,
-                    ServicePointManager.Expect100Continue,
-                    ServicePointManager.CheckCertificateRevocationList,
-                    ServicePointManager.MaxServicePoints,
-                    ServicePointManager.MaxServicePointIdleTime,
-                    ServicePointManager.DefaultConnectionLimit,
-                    ServicePointManager.DefaultPersistentConnectionLimit
-                });
+            new
+            {
+                ServicePointManager.UseNagleAlgorithm,
+                ServicePointManager.DnsRefreshTimeout,
+                ServicePointManager.Expect100Continue,
+                ServicePointManager.CheckCertificateRevocationList,
+                ServicePointManager.MaxServicePoints,
+                ServicePointManager.MaxServicePointIdleTime,
+                ServicePointManager.DefaultConnectionLimit,
+                ServicePointManager.DefaultPersistentConnectionLimit
+            });
         }
     }
 }


### PR DESCRIPTION
Sets the default connection limit on single host to 50 or to the value of env var DEFAULTCONNECTIONLIMIT. This should reduce the time it takes to get the access tokens by allowing more concurrent requests.
