### PR TITLE
Adjust threadpool settings, move service point manager

### DIFF
--- a/api/src/BcGov.Malt.Web/Infrastructure/ServicePointManagerConfiguration.cs
+++ b/api/src/BcGov.Malt.Web/Infrastructure/ServicePointManagerConfiguration.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Net;
+using Serilog;
+
+namespace BcGov.Malt.Web.Infrastructure
+{
+    public static class ServicePointManagerConfiguration
+    {
+        private const string EnvironmentVariable = "DEFAULTCONNECTIONLIMIT";
+
+        public static void Configure(ILogger logger)
+        {
+            // DefaultConnectionLimit : The maximum number of concurrent connections allowed to a single host (ServicePoint)
+            int defaultConnectionLimit;
+
+
+            var value = Environment.GetEnvironmentVariable(EnvironmentVariable);
+            if (!string.IsNullOrEmpty(value) && int.TryParse(value, out defaultConnectionLimit))
+            {
+                logger.Information("Environment variable {EnvironmentVariable} is set to {DefaultConnectionLimit}", EnvironmentVariable, defaultConnectionLimit);
+            }
+            else
+            {
+                logger.Information("Environment variable {EnvironmentVariable} is not set or is not an integer, defaulting DefaultConnectionLimit to 50", EnvironmentVariable);
+                defaultConnectionLimit = 50;
+            }
+
+            ServicePointManager.DefaultConnectionLimit = defaultConnectionLimit;
+
+            logger.Information("ServicePointManager settings = {@ServicePointManager}",
+                new
+                {
+                    ServicePointManager.UseNagleAlgorithm,
+                    ServicePointManager.DnsRefreshTimeout,
+                    ServicePointManager.Expect100Continue,
+                    ServicePointManager.CheckCertificateRevocationList,
+                    ServicePointManager.MaxServicePoints,
+                    ServicePointManager.MaxServicePointIdleTime,
+                    ServicePointManager.DefaultConnectionLimit,
+                    ServicePointManager.DefaultPersistentConnectionLimit
+                });
+        }
+    }
+}

--- a/api/src/BcGov.Malt.Web/Infrastructure/ThreadPoolConfiguration.cs
+++ b/api/src/BcGov.Malt.Web/Infrastructure/ThreadPoolConfiguration.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Threading;
+using Serilog;
+
+namespace BcGov.Malt.Web.Infrastructure
+{
+    public static class ThreadPoolConfiguration
+    {
+        /// <summary>
+        /// Sets the minimum number of threads the thread pool creates on demand.
+        /// </summary>
+        public static void Configure(ILogger logger)
+        {
+            int minWorkerThreads; // default: 8
+            int minCompletionPortThreads;   // default: 8
+            ThreadPool.GetMinThreads(out minWorkerThreads, out minCompletionPortThreads);
+
+            logger.Debug("Default ThreadPool settings {MinWorkerThreads} / {MinCompletionPortThreads}", minWorkerThreads, minCompletionPortThreads);
+
+            minWorkerThreads = GetSetting("THREADPOOL__MINWORKERTHREADS", minWorkerThreads, logger);
+            minCompletionPortThreads = GetSetting("THREADPOOL__MINIOTHREADS", minCompletionPortThreads, logger);
+
+            ThreadPool.SetMinThreads(minWorkerThreads, minCompletionPortThreads);
+            logger.Information("ThreadPool settings {MinWorkerThreads} / {MinCompletionPortThreads}", minWorkerThreads, minCompletionPortThreads);
+        }
+
+        private static int GetSetting(string name, int defaultValue, ILogger logger)
+        {
+            var stringValue = Environment.GetEnvironmentVariable(name);
+
+            if (string.IsNullOrEmpty(stringValue) || !int.TryParse(stringValue, out var value))
+            {
+                logger.Information(
+                    "Environment variable {EnvironmentVariable} is not set or is not an integer, defaulting to {Value}",
+                    name, defaultValue);
+                return defaultValue;
+            }
+            else
+            {
+                logger.Information("Environment variable {EnvironmentVariable} is set to {Value}", name, value);
+            }
+
+            return value;
+        }
+    }
+}

--- a/api/src/BcGov.Malt.Web/Program.cs
+++ b/api/src/BcGov.Malt.Web/Program.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using BcGov.Malt.Web.Infrastructure;
 using BcGov.Malt.Web.Models.Configuration;
 using BcGov.Malt.Web.Services;
 using Microsoft.AspNetCore.Hosting;
@@ -34,7 +35,8 @@ namespace BcGov.Malt.Web
             try
             {
                 // configure ServicePointManager before making any network requests
-                ConfigureServicePointManager(logger);
+                ServicePointManagerConfiguration.Configure(logger);
+                ThreadPoolConfiguration.Configure(logger);
 
                 // create the host
                 IHost host = CreateHostBuilder(args).Build();
@@ -240,36 +242,5 @@ namespace BcGov.Malt.Web
         }
 
 
-        private static void ConfigureServicePointManager(ILogger logger)
-        {
-            // DefaultConnectionLimit : The maximum number of concurrent connections allowed to a single host (ServicePoint)
-            int defaultConnectionLimit;
-            
-            var value = Environment.GetEnvironmentVariable("DEFAULTCONNECTIONLIMIT");
-            if (!string.IsNullOrEmpty(value) && int.TryParse(value, out defaultConnectionLimit))
-            {
-                logger.Information("Environment variable DEFAULTCONNECTIONLIMIT is set to {DefaultConnectionLimit}", defaultConnectionLimit);
-            }
-            else
-            {
-                logger.Information("Environment variable DEFAULTCONNECTIONLIMIT is not set or is not an integer, defaulting DefaultConnectionLimit to 50");
-                defaultConnectionLimit = 50;
-            }
-
-            ServicePointManager.DefaultConnectionLimit = defaultConnectionLimit;
-
-            logger.Information("ServicePointManager settings = {@ServicePointManager}",
-            new
-            {
-                ServicePointManager.UseNagleAlgorithm,
-                ServicePointManager.DnsRefreshTimeout,
-                ServicePointManager.Expect100Continue,
-                ServicePointManager.CheckCertificateRevocationList,
-                ServicePointManager.MaxServicePoints,
-                ServicePointManager.MaxServicePointIdleTime,
-                ServicePointManager.DefaultConnectionLimit,
-                ServicePointManager.DefaultPersistentConnectionLimit
-            });
-        }
     }
 }


### PR DESCRIPTION
# Description

- add code to adjust the threadpool settings - too few threads do not allow the completion of multiple http requests due to blocked on available threads
- move the service point manager configuration into separate class
