### PR TITLE
Add configurable request timeout using API_TIMEOUT_SECONDS variable

### DIFF
--- a/api/src/BcGov.Malt.Web/Features/Projects/AddUserToProject.cs
+++ b/api/src/BcGov.Malt.Web/Features/Projects/AddUserToProject.cs
@@ -30,14 +30,13 @@ namespace BcGov.Malt.Web.Features.Projects
             private readonly IUserSearchService _userSearchService;
             private readonly IUserManagementService _userManagementService;
             private readonly ProjectConfigurationCollection _projects;
-            private readonly ILogger<Handler> _logger;
 
             public Handler(IUserSearchService userSearchService, IUserManagementService userManagementService, ProjectConfigurationCollection projects, ILogger<Handler> logger)
+                : base(logger)
             {
                 _userSearchService = userSearchService ?? throw new ArgumentNullException(nameof(userSearchService));
                 _userManagementService = userManagementService ?? throw new ArgumentNullException(nameof(userManagementService));
                 _projects = projects ?? throw new ArgumentNullException(nameof(projects));
-                _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             }
 
             public override async Task<ProjectAccess> Handle(Request request, CancellationToken cancellationToken)
@@ -46,7 +45,7 @@ namespace BcGov.Malt.Web.Features.Projects
 
                 if (project == null)
                 {
-                    _logger.LogInformation("Project {ProjectId} not found", request.ProjectId);
+                    Logger.LogInformation("Project {ProjectId} not found", request.ProjectId);
                     throw new ProjectNotFoundException(request.ProjectId);
                 }
 
@@ -54,7 +53,7 @@ namespace BcGov.Malt.Web.Features.Projects
 
                 if (user == null)
                 {
-                    _logger.LogInformation("User {Username} not found", request.Username);
+                    Logger.LogInformation("User {Username} not found", request.Username);
                     throw new UserNotFoundException(request.Username);
                 }
 

--- a/api/src/BcGov.Malt.Web/Features/Projects/RemoveUserFromProject.cs
+++ b/api/src/BcGov.Malt.Web/Features/Projects/RemoveUserFromProject.cs
@@ -30,14 +30,13 @@ namespace BcGov.Malt.Web.Features.Projects
             private readonly IUserSearchService _userSearchService;
             private readonly IUserManagementService _userManagementService;
             private readonly ProjectConfigurationCollection _projects;
-            private readonly ILogger<Handler> _logger;
 
             public Handler(IUserSearchService userSearchService, IUserManagementService userManagementService, ProjectConfigurationCollection projects, ILogger<Handler> logger)
+                : base(logger)
             {
                 _userSearchService = userSearchService ?? throw new ArgumentNullException(nameof(userSearchService));
                 _userManagementService = userManagementService ?? throw new ArgumentNullException(nameof(userManagementService));
                 _projects = projects ?? throw new ArgumentNullException(nameof(projects));
-                _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             }
 
             public override async Task<ProjectAccess> Handle(Request request, CancellationToken cancellationToken)
@@ -46,7 +45,7 @@ namespace BcGov.Malt.Web.Features.Projects
 
                 if (project == null)
                 {
-                    _logger.LogInformation("Project {ProjectId} not found", request.ProjectId);
+                    Logger.LogInformation("Project {ProjectId} not found", request.ProjectId);
                     throw new ProjectNotFoundException(request.ProjectId);
                 }
 
@@ -54,7 +53,7 @@ namespace BcGov.Malt.Web.Features.Projects
 
                 if (user == null)
                 {
-                    _logger.LogInformation("User {Username} not found", request.Username);
+                    Logger.LogInformation("User {Username} not found", request.Username);
                     throw new UserNotFoundException(request.Username);
                 }
 

--- a/api/src/BcGov.Malt.Web/Features/RequestHandlerBase.cs
+++ b/api/src/BcGov.Malt.Web/Features/RequestHandlerBase.cs
@@ -4,21 +4,56 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
+using Microsoft.Extensions.Logging;
+using Org.BouncyCastle.Asn1.Cms;
+using ILogger = Serilog.ILogger;
 
 namespace BcGov.Malt.Web.Features
 {
     public abstract class RequestHandlerBase<TRequest, TResponse> : IRequestHandler<TRequest, TResponse>
         where TRequest : IRequest<TResponse>
     {
+        private const string EnvironmentVariable = "API_TIMEOUT_SECONDS";
+
+        protected ILogger<RequestHandlerBase<TRequest, TResponse>> Logger { get; }
+
+        protected RequestHandlerBase(ILogger<RequestHandlerBase<TRequest, TResponse>> logger)
+        {
+            Logger = logger;
+        }
+
         public abstract Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken);
 
         protected CancellationTokenSource CreateCancellationTokenSource(CancellationToken cancellationToken)
         {
 #pragma warning disable CA2000 // Dispose objects before losing scope
-            CancellationTokenSource timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            CancellationTokenSource timeout = new CancellationTokenSource(GetRequestTimeout());
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
             return CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeout.Token);
+        }
+
+        private TimeSpan GetRequestTimeout()
+        {
+            var timeout = TimeSpan.FromSeconds(30);
+
+            var stringValue = Environment.GetEnvironmentVariable(EnvironmentVariable);
+
+            // log debug cause this will be logged for every request
+
+            if (string.IsNullOrEmpty(stringValue) || !int.TryParse(stringValue, out var value))
+            {
+                Logger.LogDebug(
+                    "Environment variable {EnvironmentVariable} is not set or is not an integer, defaulting to {Value}",
+                    EnvironmentVariable, timeout);
+            }
+            else
+            {
+                timeout = TimeSpan.FromSeconds(Math.Abs(value));
+                Logger.LogDebug("Environment variable {EnvironmentVariable} is set to {Value}", EnvironmentVariable, timeout);
+            }
+
+            return timeout;
         }
     }
 }

--- a/api/src/BcGov.Malt.Web/Features/Users/Lookup.cs
+++ b/api/src/BcGov.Malt.Web/Features/Users/Lookup.cs
@@ -30,13 +30,12 @@ namespace BcGov.Malt.Web.Features.Users
         {
             private readonly IUserSearchService _userSearchService;
             private readonly IUserManagementService _userManagementService;
-            private readonly ILogger<Handler> _logger;
 
             public Handler(IUserSearchService userSearchService, IUserManagementService userManagementService, ILogger<Handler> logger)
+                : base(logger)
             {
                 _userSearchService = userSearchService ?? throw new ArgumentNullException(nameof(userSearchService));
                 _userManagementService = userManagementService ?? throw new ArgumentNullException(nameof(userManagementService));
-                _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             }
 
             public override async Task<DetailedUser> Handle(Request request, CancellationToken cancellationToken)
@@ -50,17 +49,17 @@ namespace BcGov.Malt.Web.Features.Users
                         throw new ArgumentNullException(nameof(request));
                     }
 
-                    _logger.LogDebug("Searching for user {Username}", request.Username);
+                    Logger.LogDebug("Searching for user {Username}", request.Username);
 
                     var user = await _userSearchService.SearchAsync(request.Username).ConfigureAwait(false);
 
                     if (user == null)
                     {
-                        _logger.LogDebug("Lookup for {Username} returned null, returning null", request.Username);
+                        Logger.LogDebug("Lookup for {Username} returned null, returning null", request.Username);
                         return null;
                     }
 
-                    _logger.LogDebug("Looking for project membership for user {Username}", user.UserName);
+                    Logger.LogDebug("Looking for project membership for user {Username}", user.UserName);
                     var projects = await _userManagementService.GetProjectsForUserAsync(user, cts.Token).ConfigureAwait(false);
 
                     DetailedUser result = new DetailedUser(user, projects);
@@ -69,7 +68,7 @@ namespace BcGov.Malt.Web.Features.Users
                 }
                 catch (Exception e)
                 {
-                    _logger.LogError(e, "Error lookup user");
+                    Logger.LogError(e, "Error lookup user");
                     throw;
                 }
             }

--- a/api/src/BcGov.Malt.Web/Services/Sharepoint/SamlAuthenticator.cs
+++ b/api/src/BcGov.Malt.Web/Services/Sharepoint/SamlAuthenticator.cs
@@ -173,7 +173,7 @@ namespace BcGov.Malt.Web.Services.Sharepoint
 
             using var content = new FormUrlEncodedContent(data);
 
-            var httpPostResponse = await client.PostAsync(trustUri, content).ConfigureAwait(false);
+            var httpPostResponse = await client.PostAsync("/_trust/", content).ConfigureAwait(false);
 
             // the response could be 302 as well
             if (!httpPostResponse.IsSuccessStatusCode && httpPostResponse.StatusCode != HttpStatusCode.Found)


### PR DESCRIPTION
# Description

This change adds .ConfigureAwait(false) on nested / parallel calls to prevent blocking on the SynchronizationContext

see [ConfigureAwait FAQ](https://devblogs.microsoft.com/dotnet/configureawait-faq/)

Also add configurable request timeout