### PR TITLE
revert populating metadata since it broke stuff

### DIFF
--- a/api/src/BcGov.Malt.Web/Services/DefaultODataClientFactory.cs
+++ b/api/src/BcGov.Malt.Web/Services/DefaultODataClientFactory.cs
@@ -33,7 +33,7 @@ namespace BcGov.Malt.Web.Services
             HttpClient httpClient = _httpClientFactory.CreateClient(name);
 
             ODataClientSettings settings = new ODataClientSettings(httpClient);
-            settings.MetadataDocument = GetMetadataDocument();
+            //settings.MetadataDocument = GetMetadataDocument();
 
             ////settings.TraceFilter = ODataTrace.All;
             ////settings.OnTrace = (message, args) => _odataClientLogger.LogInformation(message, args);


### PR DESCRIPTION
# Description

Temporary revert of supplying meta data automatically do to errors one some dynamics instances.
