### PR TITLE
enabled cached metadata, restrict properties returned from dynamics

### DIFF
--- a/api/src/BcGov.Malt.Web/Services/DefaultODataClientFactory.cs
+++ b/api/src/BcGov.Malt.Web/Services/DefaultODataClientFactory.cs
@@ -33,7 +33,8 @@ namespace BcGov.Malt.Web.Services
             HttpClient httpClient = _httpClientFactory.CreateClient(name);
 
             ODataClientSettings settings = new ODataClientSettings(httpClient);
-            //settings.MetadataDocument = GetMetadataDocument();
+            settings.MetadataDocument = GetMetadataDocument();
+            settings.IgnoreUnmappedProperties = true;
 
             ////settings.TraceFilter = ODataTrace.All;
             ////settings.OnTrace = (message, args) => _odataClientLogger.LogInformation(message, args);


### PR DESCRIPTION
# Description

Enabled using local metadata. Only fetch required columns.

