### PR TITLE
Avoid looking up SharePoint group names repeatedly

### DIFF
--- a/src/BcGov.Jag.AccountManagement/BcGov.Jag.AccountManagement/Server/Services/DynamicsResourceUserManagementService.cs
+++ b/src/BcGov.Jag.AccountManagement/BcGov.Jag.AccountManagement/Server/Services/DynamicsResourceUserManagementService.cs
@@ -11,17 +11,14 @@ namespace BcGov.Jag.AccountManagement.Server.Services;
 public class DynamicsResourceUserManagementService : ResourceUserManagementService
 {
     private readonly IODataClientFactory _factory;
-    private readonly IUserSearchService _userSearchService;
 
     public DynamicsResourceUserManagementService(ProjectConfiguration project,
         ProjectResource projectResource,
         IODataClientFactory factory,
-        IUserSearchService userSearchService,
         ILogger logger)
         : base(project, projectResource, logger)
     {
         _factory = factory ?? throw new ArgumentNullException(nameof(factory));
-        _userSearchService = userSearchService ?? throw new ArgumentNullException(nameof(userSearchService));
     }
 
     public override async Task<string> AddUserAsync(User user, CancellationToken cancellationToken)

--- a/src/BcGov.Jag.AccountManagement/BcGov.Jag.AccountManagement/Server/Services/SharepointResourceUserManagementService.cs
+++ b/src/BcGov.Jag.AccountManagement/BcGov.Jag.AccountManagement/Server/Services/SharepointResourceUserManagementService.cs
@@ -5,6 +5,7 @@ using BcGov.Jag.AccountManagement.Server.Infrastructure;
 using BcGov.Jag.AccountManagement.Server.Models.Configuration;
 using BcGov.Jag.AccountManagement.Server.Models.SharePoint;
 using BcGov.Jag.AccountManagement.Server.Services.Sharepoint;
+using Microsoft.Extensions.Caching.Memory;
 using Refit;
 using ILogger = Serilog.ILogger;
 
@@ -50,19 +51,19 @@ public class SharePointResourceUserManagementService : ResourceUserManagementSer
 
     private readonly RefitSettings _refitSettings = new RefitSettings();
 
-    private readonly IUserSearchService _userSearchService;
     private readonly ISamlAuthenticator _samlAuthenticator;
+    private readonly IMemoryCache _cache;
 
     public SharePointResourceUserManagementService(
         ProjectConfiguration project,
         ProjectResource projectResource,
-        IUserSearchService userSearchService,
         ISamlAuthenticator samlAuthenticator,
+        IMemoryCache cache,
         ILogger logger)
         : base(project, projectResource, logger)
     {
-        _userSearchService = userSearchService ?? throw new ArgumentNullException(nameof(userSearchService));
         _samlAuthenticator = samlAuthenticator ?? throw new ArgumentNullException(nameof(samlAuthenticator));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
     }
 
     public override async Task<string> AddUserAsync(Shared.User user, CancellationToken cancellationToken)
@@ -86,25 +87,20 @@ public class SharePointResourceUserManagementService : ResourceUserManagementSer
 
         ISharePointClient restClient = await GetSharePointRestClientForUpdate(cancellationToken);
 
-        var siteGroupTitle = await GetSiteGroupGroupNameAsync(restClient, "Members", cancellationToken);
+        var siteGroupGroups = await GetSiteGroupGroupsAsync(restClient, cancellationToken);
 
-        if (string.IsNullOrEmpty(siteGroupTitle))
+        if (siteGroupGroups is null)
         {
-            return $"Unable to get SharePoint site group name";
+            return $"Unable to get SharePoint site groups";
         }
 
         // we always add users to '<site-group> Members'
-
-        GetSiteGroupsVerboseResponse siteGroups =
-            await restClient.GetSiteGroupsByTitleAsync(siteGroupTitle, cancellationToken);
-
-        if (siteGroups.Data.Results.Count == 0)
+        SiteGroup? siteGroup = siteGroupGroups.Members;
+        if (siteGroup is null)
         {
-            Logger.Information("Cannot find site group {@SiteGroup}", new SiteGroup { Title = siteGroupTitle });
-            return $"SharePoint site group '{siteGroupTitle}' not found";
+            Logger.Information("Cannot find Members site group");
+            return "Members site group not found";
         }
-
-        var siteGroup = siteGroups.Data.Results[0];
 
         Logger.Information("Adding {Username} to site collection {@SiteGroup} for {Project} on resource {ResourceType}",
             user.UserName,
@@ -125,7 +121,7 @@ public class SharePointResourceUserManagementService : ResourceUserManagementSer
         {
             var errorResponse = await e.GetContentAsAsync<SharePointErrorResponse>();
             Logger.Warning(e, "Error adding user to SharePoint group {@Error}", errorResponse);
-            return $"Error occurred adding user to SharePoint site group '{siteGroupTitle}'";
+            return $"Error occurred adding user to SharePoint site group '{siteGroup.Title}'";
         }
     }
     
@@ -155,19 +151,16 @@ public class SharePointResourceUserManagementService : ResourceUserManagementSer
 
         ISharePointClient restClient = await GetSharePointRestClientForUpdate(cancellationToken);
 
-        var ownersGroup = await GetSiteGroupGroupNameAsync(restClient, "Owners", cancellationToken);
-        var membersGroup = await GetSiteGroupGroupNameAsync(restClient, "Members", cancellationToken);
-        var visitorsGroup = await GetSiteGroupGroupNameAsync(restClient, "Visitors", cancellationToken);
-
-        var groups = await restClient.GetSiteGroupsAsync(cancellationToken);
-        var siteGroups = groups.Data.Results;
+        var siteGroups = await GetSiteGroupGroupsAsync(restClient, cancellationToken);
+        if (siteGroups is null)
+        {
+            // log
+            return "Could not find site groups";
+        }
 
         StringBuilder response = new StringBuilder();
 
-        foreach (var siteGroup in siteGroups.Where(_ =>
-            _.Title.Equals(ownersGroup, StringComparison.OrdinalIgnoreCase) ||
-            _.Title.Equals(membersGroup, StringComparison.OrdinalIgnoreCase) ||
-            _.Title.Equals(visitorsGroup, StringComparison.OrdinalIgnoreCase)))
+        foreach (var siteGroup in siteGroups.Items)
         {
             try
             {
@@ -232,19 +225,16 @@ public class SharePointResourceUserManagementService : ResourceUserManagementSer
         // we only really want to be checking the Members group which we add/remove from
         // other groups the service account doesn't have permissions to query and flood the traces
         // with 403 errors, we always add/remove users to '<site-group> Members'
-        var ownersGroup = await GetSiteGroupGroupNameAsync(restClient, "Owners", cancellationToken);
-        var membersGroup = await GetSiteGroupGroupNameAsync(restClient, "Members", cancellationToken);
-        var visitorsGroup = await GetSiteGroupGroupNameAsync(restClient, "Visitors", cancellationToken);
-
-        var groups = await restClient.GetSiteGroupsAsync(cancellationToken);
-        var siteGroups = groups.Data.Results;
+        var siteGroups = await GetSiteGroupGroupsAsync(restClient, cancellationToken);
+        if (siteGroups is null)
+        {
+            Logger.Information("Could not get site groups");
+            return false;
+        }
 
         // service account does not have permission to view membership of "Excel Services Viewers"
         // TODO: make this configurable
-        foreach (var siteGroup in siteGroups.Where(_ =>
-            _.Title.Equals(ownersGroup, StringComparison.OrdinalIgnoreCase) ||
-            _.Title.Equals(membersGroup, StringComparison.OrdinalIgnoreCase) ||
-            _.Title.Equals(visitorsGroup, StringComparison.OrdinalIgnoreCase)))
+        foreach (var siteGroup in siteGroups.Items)
         {
             Logger.Debug("Getting users in {@SiteGroup}", siteGroup);
             try
@@ -276,15 +266,23 @@ public class SharePointResourceUserManagementService : ResourceUserManagementSer
     }
 
     /// <summary>
-    /// Gets the name of the site group group, it will be "Site Members", or null if it could not be found.
+    /// Gets the name of the built-in site group groups, or null if it could not be found.
     /// </summary>
     /// <param name="restClient"></param>
     /// <param name="groupNameSuffix"></param>
     /// <param name="restClient"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    private async Task<string?> GetSiteGroupGroupNameAsync(ISharePointClient restClient, string groupNameSuffix, CancellationToken cancellationToken)
+    private async Task<SharePointGroups?> GetSiteGroupGroupsAsync(ISharePointClient restClient, CancellationToken cancellationToken)
     {
+        // check if we have the item in cache
+        string key = $"{Project.Name}-{ProjectResource.Type}-Groups";
+
+        if (_cache.TryGetValue(key, out SharePointGroups groups))
+        {
+            return groups;
+        }
+
         GetSharePointWebVerboseResponse web = await restClient.GetWebAsync(cancellationToken);
 
         if (string.IsNullOrEmpty(web?.Data?.Title))
@@ -293,11 +291,53 @@ public class SharePointResourceUserManagementService : ResourceUserManagementSer
             return null;
         }
 
-        // we always add users to '<site-group> Members'
-        var siteGroupTitle = web.Data.Title + " " + groupNameSuffix.Trim();
-        return siteGroupTitle;
+        string siteTitle = web.Data.Title;
+
+        groups = new SharePointGroups();
+        var groupsResponse = await restClient.GetSiteGroupsAsync(cancellationToken);
+        foreach (var siteGroup in groupsResponse.Data.Results)
+        {
+            if (siteGroup.Title.Equals(siteTitle + " Owners", StringComparison.OrdinalIgnoreCase))
+            {
+                groups.Owners = siteGroup;
+            }
+            else if (siteGroup.Title.Equals(siteTitle + " Members", StringComparison.OrdinalIgnoreCase))
+            {
+                groups.Members = siteGroup;
+            }
+            else if (siteGroup.Title.Equals(siteTitle + " Visitors", StringComparison.OrdinalIgnoreCase))
+            {
+                groups.Visitors = siteGroup;
+            }
+        }
+
+        if (!groups.IsEmpty)
+        {
+            _cache.Set(key, groups);
+            return groups;
+        }
+
+        return null;
     }
 
+    private class SharePointGroups
+    {
+        public SiteGroup? Owners { get; set; }
+        public SiteGroup? Members { get; set; }
+        public SiteGroup? Visitors { get; set; }
+
+        public bool IsEmpty => Owners is null && Members is null && Visitors is null;
+
+        public IEnumerable<SiteGroup> Items
+        {
+            get
+            {
+                if (Owners is not null) yield return Owners;
+                if (Members is not null) yield return Members;
+                if (Visitors is not null) yield return Visitors;
+            }
+        }
+    }
 
     private async Task<ISharePointClient> GetSharePointRestClient()
     {


### PR DESCRIPTION
# Description

Lookup the built-in project groups once and cache them.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

